### PR TITLE
Fixing NPE in ConfigSecurities with bssid = null

### DIFF
--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConfigSecurities.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConfigSecurities.java
@@ -105,7 +105,7 @@ final class ConfigSecurities {
         if (ssid == null || ssid.isEmpty())
             return null;
 
-        final String bssid = configToFind.BSSID;
+        final String bssid = configToFind.BSSID != null ? configToFind.BSSID : "";
 
         final String security = getSecurity(configToFind);
 


### PR DESCRIPTION
#### Description

Addresses bug "Crash when trying to connect to secure network with no password #13"

#### Solution
Adds null handling 
